### PR TITLE
Update prize card removal log

### DIFF
--- a/PTCGLDeckTracker/CardCollection/PrizeCards.cs
+++ b/PTCGLDeckTracker/CardCollection/PrizeCards.cs
@@ -56,7 +56,7 @@ namespace PTCGLDeckTracker.CardCollection
         public override void OnCardRemoved(Card3D cardRemoved)
         {
             base.OnCardRemoved(cardRemoved);
-            Melon<IronTracks>.Logger.Msg("Added Card " + cardRemoved.name + " into hand.");
+            Melon<IronTracks>.Logger.Msg("Removed Card " + cardRemoved.name + " from prize cards.");
             // Ignore if the card is unknown (this technically shouldn't be possible AFAIK)
             if (string.IsNullOrEmpty(cardRemoved.entityID) || cardRemoved.entityID.Equals("PRIVATE"))
             {


### PR DESCRIPTION
## Summary
- fix log output when removing prize cards

## Testing
- `dotnet build PTCGLDeckTracker/PTCGLDeckTracker.csproj -c Release` *(fails: reference assemblies for .NETFramework v4.7.2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406746781c832c997c73bd35713c5e