### PR TITLE
Remove nullability warnings for Card properties

### DIFF
--- a/PTCGLDeckTracker/CardCollection/Card.cs
+++ b/PTCGLDeckTracker/CardCollection/Card.cs
@@ -12,8 +12,8 @@ namespace PTCGLDeckTracker.CardCollection
     {
         public string cardID { get; set; }
         public int quantity { get; set; }
-        public string englishName { get; set; }
-        public string setID {  get; set; }
+        public string englishName { get; set; } = string.Empty;
+        public string setID {  get; set; } = string.Empty;
 
         public Card(string cardID)
         {


### PR DESCRIPTION
## Summary
- ensure `englishName` and `setID` properties have default values to avoid CS8618

## Testing
- `dotnet test ./PTCGLDeckTracker.Tests/PTCGLDeckTracker.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68406d4a309c832ca73f4695a4197795