### PR TITLE
Track active/bench Pokémon and energies

### DIFF
--- a/PTCGLDeckTracker/IronTracks.cs
+++ b/PTCGLDeckTracker/IronTracks.cs
@@ -157,6 +157,48 @@ namespace PTCGLDeckTracker
                 player.OnRemovedCardFromCollection(data.card, __instance);
             }
         }
+
+        [HarmonyPatch]
+        class AttachEnergyPatch
+        {
+            static System.Reflection.MethodBase TargetMethod()
+            {
+                var type = HarmonyLib.AccessTools.TypeByName("AttachEnergyAction");
+                return type != null ? HarmonyLib.AccessTools.Method(type, "Execute") : null;
+            }
+            static void Postfix(dynamic __instance)
+            {
+                Card3D energy = null;
+                Card3D pokemon = null;
+                try { energy = __instance.energyCard as Card3D; } catch { }
+                try { pokemon = __instance.targetCard as Card3D; } catch { }
+                if (energy != null && pokemon != null)
+                {
+                    player.OnEnergyAttached(energy, pokemon);
+                }
+            }
+        }
+
+        [HarmonyPatch]
+        class DetachEnergyPatch
+        {
+            static System.Reflection.MethodBase TargetMethod()
+            {
+                var type = HarmonyLib.AccessTools.TypeByName("DetachEnergyAction");
+                return type != null ? HarmonyLib.AccessTools.Method(type, "Execute") : null;
+            }
+            static void Postfix(dynamic __instance)
+            {
+                Card3D energy = null;
+                Card3D pokemon = null;
+                try { energy = __instance.energyCard as Card3D; } catch { }
+                try { pokemon = __instance.targetCard as Card3D; } catch { }
+                if (energy != null && pokemon != null)
+                {
+                    player.OnEnergyDetached(energy, pokemon);
+                }
+            }
+        }
     }
 
 }

--- a/PTCGLDeckTracker/Player.cs
+++ b/PTCGLDeckTracker/Player.cs
@@ -20,6 +20,10 @@ namespace PTCGLDeckTracker
         public Deck deck { get; set; }
         public DiscardPile discardPile { get; set; }
         public Hand hand { get; set; }
+        public Card3D activePokemon { get; private set; }
+        public List<Card3D> benchPokemon { get; } = new List<Card3D>();
+        // key: pokemon entityID
+        private Dictionary<string, List<Card3D>> _attachedEnergies = new Dictionary<string, List<Card3D>>();
 
         public Player()
         {
@@ -29,35 +33,115 @@ namespace PTCGLDeckTracker
             this.username = string.Empty;
         }
 
+        private string GetKey(Card3D card) => card.entityID;
+
+        public void SetActivePokemon(Card3D card)
+        {
+            activePokemon = card;
+            var key = GetKey(card);
+            if (!_attachedEnergies.ContainsKey(key))
+            {
+                _attachedEnergies[key] = new List<Card3D>();
+            }
+        }
+
+        public void AddBenchPokemon(Card3D card)
+        {
+            benchPokemon.Add(card);
+            var key = GetKey(card);
+            if (!_attachedEnergies.ContainsKey(key))
+            {
+                _attachedEnergies[key] = new List<Card3D>();
+            }
+        }
+
+        public void RemoveBenchPokemon(Card3D card)
+        {
+            benchPokemon.RemoveAll(c => c.entityID == card.entityID);
+            _attachedEnergies.Remove(GetKey(card));
+        }
+
+        public void AttachEnergy(Card3D pokemon, Card3D energy)
+        {
+            var key = GetKey(pokemon);
+            if (!_attachedEnergies.ContainsKey(key))
+            {
+                _attachedEnergies[key] = new List<Card3D>();
+            }
+            _attachedEnergies[key].Add(energy);
+        }
+
+        public void DetachEnergy(Card3D pokemon, Card3D energy)
+        {
+            var key = GetKey(pokemon);
+            if (_attachedEnergies.ContainsKey(key))
+            {
+                _attachedEnergies[key].RemoveAll(e => e.entityID == energy.entityID);
+            }
+        }
+
+        public void OnEnergyAttached(Card3D energy, Card3D pokemon)
+        {
+            AttachEnergy(pokemon, energy);
+        }
+
+        public void OnEnergyDetached(Card3D energy, Card3D pokemon)
+        {
+            DetachEnergy(pokemon, energy);
+        }
+
+
         public void OnGainCardIntoCollection(Card3D cardAdded, PlayerCardOwner playerCardOwner)
         {
-            if (playerCardOwner.GetType() == typeof(DeckController))
+            var ownerName = playerCardOwner.GetType().Name;
+            if (ownerName.Contains("Deck"))
             {
                 deck.OnCardAdded(cardAdded);
             }
-            else if (playerCardOwner.GetType() == typeof(HandFanController))
+            else if (ownerName.Contains("Hand"))
             {
                 hand.OnCardAdded(cardAdded);
             }
-            else if (playerCardOwner.GetType() == typeof(PrizeController))
+            else if (ownerName.Contains("Prize"))
             {
                 deck.prizeCards.OnCardAdded(cardAdded);
+            }
+            else if (ownerName.Contains("Bench"))
+            {
+                AddBenchPokemon(cardAdded);
+            }
+            else if (ownerName.Contains("Active"))
+            {
+                SetActivePokemon(cardAdded);
             }
         }
 
         public void OnRemovedCardFromCollection(Card3D cardRemoved, PlayerCardOwner playerCardOwner)
         {
-            if (playerCardOwner.GetType() == typeof(DeckController))
+            var ownerName = playerCardOwner.GetType().Name;
+            if (ownerName.Contains("Deck"))
             {
                 deck.OnCardRemoved(cardRemoved);
             }
-            else if (playerCardOwner.GetType() == typeof(HandFanController))
+            else if (ownerName.Contains("Hand"))
             {
                 hand.OnCardRemoved(cardRemoved);
             }
-            else if (playerCardOwner.GetType() == typeof(PrizeController))
+            else if (ownerName.Contains("Prize"))
             {
                 deck.prizeCards.OnCardRemoved(cardRemoved);
+            }
+            else if (ownerName.Contains("Bench"))
+            {
+                RemoveBenchPokemon(cardRemoved);
+            }
+            else if (ownerName.Contains("Active"))
+            {
+                if (activePokemon != null && activePokemon.entityID == cardRemoved.entityID)
+                {
+                    activePokemon = null;
+                }
+                _attachedEnergies.Remove(cardRemoved.entityID);
             }
         }
 
@@ -69,6 +153,11 @@ namespace PTCGLDeckTracker
         public void ClearCollections()
         {
             deck.Clear();
+            discardPile.Clear();
+            hand.Clear();
+            activePokemon = null;
+            benchPokemon.Clear();
+            _attachedEnergies.Clear();
         }
     }
 }


### PR DESCRIPTION
## Summary
- track active Pokémon, bench and energy attachments inside `Player`
- update board state when cards change zones
- hook into energy attach/detach actions

## Testing
- `dotnet test PTCGLDeckTracker.Tests/PTCGLDeckTracker.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68406c69bc60832c8a92025f6acddec5