### PR TITLE
Add simple advisor AI for next actions

### DIFF
--- a/PTCGLDeckTracker/ActionAdvisor.cs
+++ b/PTCGLDeckTracker/ActionAdvisor.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PTCGLDeckTracker.CardCollection;
+
+namespace PTCGLDeckTracker
+{
+    internal static class ActionAdvisor
+    {
+        public static List<string> GetSuggestions(Player player)
+        {
+            var suggestions = new List<string>();
+            var handCards = player.hand.GetCards();
+
+            if (handCards.Count == 0)
+            {
+                suggestions.Add("Your hand is empty");
+                return suggestions;
+            }
+
+            // Suggest attaching an energy card if available
+            var energyCard = handCards.Values.FirstOrDefault(c => c.englishName?.Contains("Energy", StringComparison.OrdinalIgnoreCase) == true);
+            if (energyCard != null)
+            {
+                suggestions.Add("Consider attaching an Energy card: " + energyCard.englishName);
+            }
+
+            // Suggest playing a trainer card if available
+            var trainerCard = handCards.Values.FirstOrDefault(c => c.englishName?.Contains("Trainer", StringComparison.OrdinalIgnoreCase) == true);
+            if (trainerCard != null)
+            {
+                suggestions.Add("You have a Trainer card that might help: " + trainerCard.englishName);
+            }
+
+            // Suggest playing a pokemon if available
+            var pokemonCard = handCards.Values.FirstOrDefault(c => !(c.englishName?.Contains("Energy", StringComparison.OrdinalIgnoreCase) == true) && !(c.englishName?.Contains("Trainer", StringComparison.OrdinalIgnoreCase) == true));
+            if (pokemonCard != null)
+            {
+                suggestions.Add("Consider playing Pokemon: " + pokemonCard.englishName);
+            }
+
+            if (suggestions.Count == 0)
+            {
+                suggestions.Add("No obvious actions found");
+            }
+            return suggestions;
+        }
+    }
+}

--- a/PTCGLDeckTracker/CardCollection/CardCollection.cs
+++ b/PTCGLDeckTracker/CardCollection/CardCollection.cs
@@ -45,5 +45,10 @@ namespace PTCGLDeckTracker.CardCollection
         {
             _cardCount--;
         }
+
+        public IReadOnlyDictionary<string, Card> GetCards()
+        {
+            return _cards;
+        }
     }
 }

--- a/PTCGLDeckTracker/IronTracks.cs
+++ b/PTCGLDeckTracker/IronTracks.cs
@@ -18,6 +18,7 @@ namespace PTCGLDeckTracker
     {
         bool enableDeckTracker = false;
         bool enablePrizeCards = false;
+        bool enableActionAdvisor = false;
         static Player player = new Player();
         const String GAME_SCENE_NAME = "Match_Landscape";
 
@@ -32,6 +33,11 @@ namespace PTCGLDeckTracker
             {
                 enablePrizeCards = !enablePrizeCards;
                 LoggerInstance.Msg("Toggled Prize Tracker: " + enablePrizeCards.ToString());
+            }
+            else if (Input.GetKeyDown(KeyCode.V))
+            {
+                enableActionAdvisor = !enableActionAdvisor;
+                LoggerInstance.Msg("Toggled Action Advisor: " + enableActionAdvisor.ToString());
             }
             else if (Input.GetKeyDown(KeyCode.C) && SceneManager.GetActiveScene().name == GAME_SCENE_NAME)
             {
@@ -88,6 +94,23 @@ namespace PTCGLDeckTracker
                 var textLocation = new Rect(5, height + 25, width, 500);
                 GUI.Box(location, "Prize Cards");
                 GUI.Label(textLocation, player.GetPrizeCards().PrizeCardStringForRender(), deckGUIStyle);
+            }
+
+            if (enableActionAdvisor)
+            {
+                var suggestions = ActionAdvisor.GetSuggestions(player);
+                var text = string.Join("\n", suggestions);
+                var width = 300;
+                var boxHeight = Math.Max(100, text.Count(c => c == '\n') * 20 + 25);
+                var location = new Rect(0, 0, width, boxHeight);
+                var textLocation = new Rect(5, 25, width, boxHeight);
+
+                var guiStyle = new GUIStyle();
+                guiStyle.normal.textColor = Color.white;
+                guiStyle.fontSize = 15;
+
+                GUI.Box(location, "Advisor");
+                GUI.Label(textLocation, text, guiStyle);
             }
         }
 

--- a/PTCGLDeckTracker/PTCGLDeckTracker.csproj
+++ b/PTCGLDeckTracker/PTCGLDeckTracker.csproj
@@ -96,6 +96,7 @@
     <Compile Include="CardCollection\Hand.cs" />
     <Compile Include="CardCollection\PrizeCards.cs" />
     <Compile Include="IronTracks.cs" />
+    <Compile Include="ActionAdvisor.cs" />
     <Compile Include="Player.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- expose cards from CardCollection
- add ActionAdvisor helper
- display advisor suggestions with hotkey `V`
- include ActionAdvisor in project build

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406a04bb5c832ca9ef3b82ca47b533