### PR TITLE
Fix tests and cleanup Player

### DIFF
--- a/PTCGLDeckTracker.Tests/ActionAdvisorTests.cs
+++ b/PTCGLDeckTracker.Tests/ActionAdvisorTests.cs
@@ -56,7 +56,9 @@ public class ActionAdvisorTests
         Assert.Equal(2, suggestions.Count);
         Assert.Equal("Switch to Charizard", suggestions[0]);
         Assert.Equal("Attack with Charizard for 150 damage", suggestions[1]);
+    }
 
+    [Fact]
     public void Advisor_SelectsHighestDamageAttack()
     {
         var pikachu = new PokemonCard("Pikachu", new Attack("Thunderbolt", 100, 2));
@@ -68,7 +70,7 @@ public class ActionAdvisorTests
         state.HandEnergies.Add("L");
         state.HandEnergies.Add("F");
 
-        string suggestion = ActionAdvisor.GetSuggestions(state);
+        string suggestion = Gameplay.ActionAdvisor.GetSuggestions(state);
 
         Assert.Contains("Pikachu", suggestion);
         Assert.Contains("Thunderbolt", suggestion);
@@ -87,10 +89,9 @@ public class ActionAdvisorTests
         state.HandEnergies.Add("W");
         state.HandTrainers.Add("EnergySearch");
 
-        string suggestion = ActionAdvisor.GetSuggestions(state);
+        string suggestion = Gameplay.ActionAdvisor.GetSuggestions(state);
 
         Assert.Contains("Blastoise", suggestion);
         Assert.Contains("150", suggestion);
-
     }
 }

--- a/PTCGLDeckTracker/Player.cs
+++ b/PTCGLDeckTracker/Player.cs
@@ -1,12 +1,7 @@
-﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MelonLoader;
 using PTCGLDeckTracker.CardCollection;
-using static ContentItemCellRow;
-using static MelonLoader.MelonLogger;
 using TPCI.Rainier.Match.Cards.Ownership;
 using TPCI.Rainier.Match.Cards;
 


### PR DESCRIPTION
## Summary
- close method and add missing `[Fact]` in `ActionAdvisorTests`
- use `Gameplay.ActionAdvisor` in tests to avoid wrong overload
- clean up unnecessary `using` directives in `Player.cs`

## Testing
- `dotnet test PTCGLDeckTracker.Tests/PTCGLDeckTracker.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68406ff4df68832cb83613a2594cd83e