### PR TITLE
Enhance advisor scoring

### DIFF
--- a/PTCGLDeckTracker.Tests/ActionAdvisorTests.cs
+++ b/PTCGLDeckTracker.Tests/ActionAdvisorTests.cs
@@ -94,4 +94,36 @@ public class ActionAdvisorTests
         Assert.Contains("Blastoise", suggestion);
         Assert.Contains("150", suggestion);
     }
+
+    [Fact]
+    public void Advisor_PrefersLowerEnergyCostWhenDamageEqual()
+    {
+        var player = new Player();
+        var expensive = new Card("p1")
+        {
+            englishName = "Expensive",
+            attackDamage = 80,
+            energyRequirements = new Dictionary<string, int> { { "Fire", 3 } }
+        };
+        var cheap = new Card("p2")
+        {
+            englishName = "Cheap",
+            attackDamage = 80,
+            energyRequirements = new Dictionary<string, int> { { "Fire", 2 } }
+        };
+
+        player.SetActivePokemon(expensive);
+        player.AttachEnergy(expensive, new Card("e1") { englishName = "Fire" });
+        player.AttachEnergy(expensive, new Card("e2") { englishName = "Fire" });
+        player.AttachEnergy(expensive, new Card("e3") { englishName = "Fire" });
+
+        player.AddBenchPokemon(cheap);
+        player.AttachEnergy(cheap, new Card("e4") { englishName = "Fire" });
+        player.AttachEnergy(cheap, new Card("e5") { englishName = "Fire" });
+
+        var suggestions = ActionAdvisor.GetSuggestions(player);
+        Assert.Equal(2, suggestions.Count);
+        Assert.Equal("Switch to Cheap", suggestions[0]);
+        Assert.Equal("Attack with Cheap for 80 damage", suggestions[1]);
+    }
 }

--- a/PTCGLDeckTracker/ActionAdvisor.cs
+++ b/PTCGLDeckTracker/ActionAdvisor.cs
@@ -17,7 +17,7 @@ namespace PTCGLDeckTracker
             candidates.AddRange(player.Bench);
 
             Player.PokemonSlot? best = null;
-            int bestDamage = -1;
+            int bestScore = int.MinValue;
 
             foreach (var slot in candidates)
             {
@@ -33,10 +33,15 @@ namespace PTCGLDeckTracker
                         break;
                     }
                 }
-                if (meets && slot.Pokemon.attackDamage > bestDamage)
+                if (meets)
                 {
-                    bestDamage = slot.Pokemon.attackDamage;
-                    best = slot;
+                    int requirement = slot.Pokemon.energyRequirements.Values.Sum();
+                    int score = slot.Pokemon.attackDamage * 10 - requirement;
+                    if (score > bestScore)
+                    {
+                        bestScore = score;
+                        best = slot;
+                    }
                 }
             }
 

--- a/PTCGLDeckTracker/Gameplay/ActionAdvisor.cs
+++ b/PTCGLDeckTracker/Gameplay/ActionAdvisor.cs
@@ -9,7 +9,7 @@ namespace PTCGLDeckTracker.Gameplay
         {
             int availableEnergy = state.HandEnergies.Count + state.HandTrainers.Count;
             string bestPlay = "No available plays";
-            int bestDamage = -1;
+            int bestScore = int.MinValue;
 
             IEnumerable<PokemonCard?> candidates = new[] { state.ActivePokemon }
                 .Concat(state.BenchPokemon)
@@ -25,11 +25,14 @@ namespace PTCGLDeckTracker.Gameplay
                     if (totalEnergy < attack.EnergyCost)
                         continue;
 
-                    if (attack.Damage > bestDamage)
+                    int requiredAttachments = attack.EnergyCost - pokemon.AttachedEnergy;
+                    if (requiredAttachments < 0) requiredAttachments = 0;
+
+                    int score = attack.Damage * 10 - requiredAttachments;
+
+                    if (score > bestScore)
                     {
-                        bestDamage = attack.Damage;
-                        int requiredAttachments = attack.EnergyCost - pokemon.AttachedEnergy;
-                        if (requiredAttachments < 0) requiredAttachments = 0;
+                        bestScore = score;
                         bestPlay = $"Play {pokemon.Name}, attach {requiredAttachments} Energy, use {state.HandTrainers.Count} Trainer(s), attack with {attack.Name} for {attack.Damage} damage";
                     }
                 }


### PR DESCRIPTION
## Summary
- tweak ActionAdvisor algorithm to rank by damage and energy cost
- apply same approach to gameplay board evaluation
- add regression test showing lower energy cost is chosen when damage is equal

## Testing
- `dotnet test PTCGLDeckTracker.Tests/PTCGLDeckTracker.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68407129b43c832c9d95fbd8c6f2a082