### PR TITLE
Remove unused ComTypes using

### DIFF
--- a/PTCGLDeckTracker/Properties/AssemblyInfo.cs
+++ b/PTCGLDeckTracker/Properties/AssemblyInfo.cs
@@ -1,10 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
 using MelonLoader;
 using PTCGLDeckTracker; // The namespace of your mod class
-// ...
 [assembly: MelonInfo(typeof(IronTracks), "Iron Tracks", "1.2.0", "Bratah")]
 [assembly: MelonGame("pokemon", "Pokemon TCG Live")]
 


### PR DESCRIPTION
## Summary
- clean up AssemblyInfo.cs
- remove unused `System.Runtime.InteropServices.ComTypes` import
- drop placeholder comment

## Testing
- `dotnet test PTCGLDeckTracker.Tests/PTCGLDeckTracker.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68407e32591c832c912e256b97212eae