### PR TITLE
Fix duplicate assembly attributes

### DIFF
--- a/PTCGLDeckTracker/PTCGLDeckTracker.csproj
+++ b/PTCGLDeckTracker/PTCGLDeckTracker.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>PTCGLDeckTracker</RootNamespace>
+    <!-- Prevent SDK from generating assembly attributes -->
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- disable SDK-generated assembly info to avoid duplicate attributes

## Testing
- `dotnet restore PTCGLDeckTracker/PTCGLDeckTracker.sln` *(fails: unable to resolve packages)*

------
https://chatgpt.com/codex/tasks/task_e_68407e334e6c832cb68dfd22ed198809