### PR TITLE
Add PTCGL_PATH build variable

### DIFF
--- a/PTCGLDeckTracker/PTCGLDeckTracker.csproj
+++ b/PTCGLDeckTracker/PTCGLDeckTracker.csproj
@@ -3,44 +3,47 @@
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>PTCGLDeckTracker</RootNamespace>
+    <!-- Path to the Pokemon TCG Live installation.
+         Override with /p:PTCGL_PATH=path/to/game -->
+    <PTCGL_PATH Condition="'$(PTCGL_PATH)' == ''">E:\PTCGL\Pokemon Trading Card Game Live</PTCGL_PATH>
   </PropertyGroup>
 
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>E:\PTCGL\Pokemon Trading Card Game Live\MelonLoader\0Harmony.dll</HintPath>
+      <HintPath>$(PTCGL_PATH)\MelonLoader\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>E:\PTCGL\Pokemon Trading Card Game Live\Pokemon TCG Live_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(PTCGL_PATH)\Pokemon TCG Live_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>E:\PTCGL\Pokemon Trading Card Game Live\Pokemon TCG Live_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>$(PTCGL_PATH)\Pokemon TCG Live_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="CardDatabase.DataAccess">
-      <HintPath>E:\PTCGL\Pokemon Trading Card Game Live\Pokemon TCG Live_Data\Managed\CardDatabase.DataAccess.dll</HintPath>
+      <HintPath>$(PTCGL_PATH)\Pokemon TCG Live_Data\Managed\CardDatabase.DataAccess.dll</HintPath>
     </Reference>
     <Reference Include="MatchLogic">
-      <HintPath>E:\PTCGL\Pokemon Trading Card Game Live\Pokemon TCG Live_Data\Managed\MatchLogic.dll</HintPath>
+      <HintPath>$(PTCGL_PATH)\Pokemon TCG Live_Data\Managed\MatchLogic.dll</HintPath>
     </Reference>
     <Reference Include="MelonLoader">
-      <HintPath>E:\PTCGL\Pokemon Trading Card Game Live\MelonLoader\MelonLoader.dll</HintPath>
+      <HintPath>$(PTCGL_PATH)\MelonLoader\MelonLoader.dll</HintPath>
     </Reference>
     <Reference Include="RainierClientSDK">
-      <HintPath>E:\PTCGL\Pokemon Trading Card Game Live\Pokemon TCG Live_Data\Managed\RainierClientSDK.dll</HintPath>
+      <HintPath>$(PTCGL_PATH)\Pokemon TCG Live_Data\Managed\RainierClientSDK.dll</HintPath>
     </Reference>
     <Reference Include="SharedLogicUtils">
-      <HintPath>E:\PTCGL\Pokemon Trading Card Game Live\Pokemon TCG Live_Data\Managed\SharedLogicUtils.dll</HintPath>
+      <HintPath>$(PTCGL_PATH)\Pokemon TCG Live_Data\Managed\SharedLogicUtils.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>E:\PTCGL\Pokemon Trading Card Game Live\Pokemon TCG Live_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(PTCGL_PATH)\Pokemon TCG Live_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>E:\PTCGL\Pokemon Trading Card Game Live\Pokemon TCG Live_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(PTCGL_PATH)\Pokemon TCG Live_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>E:\PTCGL\Pokemon Trading Card Game Live\Pokemon TCG Live_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>$(PTCGL_PATH)\Pokemon TCG Live_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>E:\PTCGL\Pokemon Trading Card Game Live\Pokemon TCG Live_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>$(PTCGL_PATH)\Pokemon TCG Live_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ Cross‑platform builds are still experimental because the game libraries are
 Windows‑only, but targeting .NET 8 allows the project to compile on more
 platforms as long as the proprietary dependencies are available.
 
+The project references DLLs from the game's installation folder. Set the
+`PTCGL_PATH` MSBuild property to point to your copy of *Pokemon TCG Live* so
+that the build system can locate these files. You can pass it on the command
+line:
+
+```bash
+dotnet build -p:PTCGL_PATH="C:\\Games\\Pokemon TCG Live"
+```
+
+Or create a `Directory.Build.props` file in the repository root defining the
+`PTCGL_PATH` property for repeated builds.
+
 # Developer Notes/FAQ
 - Q: My MelonLoader isn't loading your mod correctly, how do I fix this?
   - A: The only valid Melon Loader version for the current PTCGL is v0.5.7


### PR DESCRIPTION
## Summary
- introduce `PTCGL_PATH` MSBuild property for the game install directory
- reference DLLs using that property
- document how to set `PTCGL_PATH`

## Testing
- `dotnet test PTCGLDeckTracker.Tests/PTCGLDeckTracker.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68407e346858832c9a849a25937bfde9